### PR TITLE
New public API annotation for paged requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.co.crunch</groupId>
     <artifactId>crunch-services-plugin-api</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
     <name>crunch-services-plugin API</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.4.31</kotlin.version>
+        <swagger-annotations.version>1.5.16</swagger-annotations.version>
     </properties>
 
     <build>
@@ -83,6 +84,13 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
+        </dependency>
+
+        <!-- Swagger annotations -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-annotations.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.4.30</kotlin.version>
+        <kotlin.version>1.4.31</kotlin.version>
     </properties>
 
     <build>

--- a/src/main/java/uk/co/crunch/platform/api/publicapi/PageableConstants.kt
+++ b/src/main/java/uk/co/crunch/platform/api/publicapi/PageableConstants.kt
@@ -1,0 +1,8 @@
+package uk.co.crunch.platform.api.publicapi
+
+object PageableConstants {
+    /**
+     * Maximum & default page size that Crunch allows for paged REST calls.
+     */
+    const val MAX_PAGE_SIZE = 20L
+}

--- a/src/main/java/uk/co/crunch/platform/api/publicapi/PagedRequest.kt
+++ b/src/main/java/uk/co/crunch/platform/api/publicapi/PagedRequest.kt
@@ -1,0 +1,46 @@
+package uk.co.crunch.platform.api.publicapi
+
+import io.swagger.annotations.ApiImplicitParam
+import io.swagger.annotations.ApiImplicitParams
+import uk.co.crunch.platform.api.publicapi.PageableConstants.MAX_PAGE_SIZE
+
+/**
+ * Annotation to be applied to public API requests which are supposed to return paged results for the purpose of
+ * generating the swagger documentation of the paging & sorting parameters.
+ *
+ * This annotation must be added to the public API endpoint definitions that use Spring's `Pageable`.
+ */
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.CLASS
+)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiImplicitParams(
+    ApiImplicitParam(
+        name = "page",
+        value = "The index of the page to retrieve, based at 0.",
+        paramType = "query",
+        type = "integer",
+        format = "int32"
+    ),
+    ApiImplicitParam(
+        name = "size",
+        value = "Number of records returned per page. Maximum value allowed is $MAX_PAGE_SIZE.",
+        defaultValue = "20",
+        paramType = "query",
+        type = "integer",
+        format = "int32"
+    ),
+    ApiImplicitParam(
+        name = "sort",
+        value = "Sorting criteria by a given <code>field</code>.",
+        allowMultiple = true,
+        paramType = "query",
+        type = "string",
+        format = "&lt;field&gt;[,asc&#124;desc]"
+    )
+)
+annotation class PagedRequest 

--- a/src/test/java/uk/co/crunch/platform/api/publicapi/PagedRequestUnitTest.kt
+++ b/src/test/java/uk/co/crunch/platform/api/publicapi/PagedRequestUnitTest.kt
@@ -1,0 +1,28 @@
+package uk.co.crunch.platform.api.publicapi
+
+import io.swagger.annotations.ApiParam
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class PagedRequestUnitTest {
+
+    @Test
+    fun `paged requests are annotated with @PagedRequest`() {
+        DemoRestControllerWithPagedRequest::class.java
+            .getMethod("getPaged", Pageable::class.java)
+            .getAnnotation(PagedRequest::class.java)
+            .run { assertThat(this).isNotNull }
+    }
+}
+
+//@RestController
+//@RequestMapping("/demo")
+class DemoRestControllerWithPagedRequest {
+
+    @PagedRequest
+    // @GetMapping("/paged", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getPaged(@ApiParam(hidden = true) pageData: Pageable) = listOf("a", "b", "c")
+}
+
+// i.e. org.springframework.data.domain.Pageable
+class Pageable


### PR DESCRIPTION
Add `PagedRequest` annotation to be used with paged public API REST endpoint definitions for the purpose of generating swagger documentation about the paging data.